### PR TITLE
Chain ID Fix

### DIFF
--- a/src/rpc/calls/chainId.ts
+++ b/src/rpc/calls/chainId.ts
@@ -1,5 +1,4 @@
 import { RPCError, RPCRequest, RPCResponse } from '../../types/types'
-import { callStarknet } from '../../utils/callHelper'
 
 export async function chainIdHandler(
   request: RPCRequest,
@@ -14,6 +13,7 @@ export async function chainIdHandler(
     }
   }
 
+  /*
   const response: RPCResponse | string = await callStarknet('testnet', {
     jsonrpc: request.jsonrpc,
     method: 'starknet_chainId',
@@ -27,11 +27,18 @@ export async function chainIdHandler(
       message: 'Starknet RPC error',
       data: response,
     }
-  }
+  } */
 
+  ///
+  // TODO: Starknet chain id length is too high for metamask and trustwallet.
+  // we use SNSEP for sepolia SNMAN for mainnet
+  // const formattedChainId = response.result === '0x534e5f5345504f4c4941' ? '0x534e534550' : '0x534e4d414e'
+
+  // Return directly SNSEP while developing
+  const chainId = '0x534e534550'
   return {
     jsonrpc: '2.0',
     id: 1,
-    result: response.result,
+    result: chainId,
   }
 }

--- a/tests/rpc/calls/chainId.test.ts
+++ b/tests/rpc/calls/chainId.test.ts
@@ -11,6 +11,6 @@ describe('Test Chain ID request testnet', () => {
     }
     const result: RPCResponse = <RPCResponse>await chainIdHandler(request)
 
-    expect(result.result).toBe('0x534e5f5345504f4c4941')
+    expect(result.result).toBe('0x534e534550')
   })
 })


### PR DESCRIPTION
We return custom chain id from now. Ethereum wallets is not supporting size of SN_MAIN as chain id

So we use

SNMAN => mainnet
SNSEP => sepolia

Will keep use these chain ids or have to discuss with wallet providers to fix this problem. 