### PR TITLE
Started to using new abiFormatter for sendRawTransaction calldata

### DIFF
--- a/src/utils/calldata.ts
+++ b/src/utils/calldata.ts
@@ -1,3 +1,4 @@
+import { AbiCoder } from 'ethers'
 import { EthereumSlot } from '../types/types'
 import { Uint256ToU256 } from './converters/integer'
 import { getSnAddressFromEthAddress } from './wrapper'
@@ -180,4 +181,13 @@ function ethTypeBitLength(type: string): number {
     default:
       return 0
   }
+}
+
+export function decodeCalldataWithTypes(types: Array<string>, data: string) {
+  if (types.length == 0 || data.length == 0) {
+    return
+  }
+
+  const decoder = new AbiCoder()
+  return decoder.decode(types, data)
 }

--- a/src/utils/felt.ts
+++ b/src/utils/felt.ts
@@ -4,7 +4,7 @@ export function convertHexChunkIntoFeltArray(chunk: string): Array<string> {
   return convertChunkIntoHexStringArray(chunk, chunkSize)
 }
 
-export function convertHextIntoBytesArray(chunk: string): Array<string> {
+export function convertHexIntoBytesArray(chunk: string): Array<string> {
   const chunkSize = 2
   return convertChunkIntoHexStringArray(chunk, chunkSize)
 }

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -1,4 +1,4 @@
-import { isHexString } from 'ethers'
+import { isHexString, Transaction } from 'ethers'
 import { addHexPrefix, removeHexPrefix } from './padding'
 export function validateEthAddress(ethAddress: string): boolean {
   if (!ethAddress) {
@@ -59,4 +59,16 @@ export function validateBlockNumber(value: string | number): boolean {
       }
       return false
   }
+}
+
+export function validateRawTransaction(tx: Transaction): boolean {
+  // Add more sync validations
+
+  const calldata = tx.data
+
+  if (calldata.length < 10) {
+    return false // Empty calldata
+  }
+
+  return true
 }

--- a/tests/utils/felt.test.ts
+++ b/tests/utils/felt.test.ts
@@ -1,6 +1,6 @@
 import {
   convertHexChunkIntoFeltArray,
-  convertHextIntoBytesArray,
+  convertHexIntoBytesArray,
 } from '../../src/utils/felt'
 describe('Test split of signed raw transaction', () => {
   it('Splits data can fit one felt', async () => {
@@ -31,7 +31,7 @@ describe('Test split of signed raw transaction', () => {
   it('Splits data to bytes', async () => {
     const data = '0xABCABDABEABFFFF'
 
-    const chunks: Array<string> = convertHextIntoBytesArray(data)
+    const chunks: Array<string> = convertHexIntoBytesArray(data)
     expect(chunks.length).toBe(8)
     expect(chunks[0]).toBe('0xAB')
     expect(chunks[1]).toBe('0xCA')


### PR DESCRIPTION
Maybe we can send call data directly parsed by the node. Do we really need to pass rlp encoded?

The contract needs to verify that the transaction is signed correctly and that the target contract is registered on the lens.

But can we pass the signed raw transaction properties already decoded? In all cases, tx hash has to be the same. 

TODO: discuss this with the team in following week
