### PR TITLE
Handle special case when converting from felt to uint256

### DIFF
--- a/src/utils/calldata.ts
+++ b/src/utils/calldata.ts
@@ -228,7 +228,10 @@ export function mergeSlots(
     const currentType = types[typeIndex];
 
     if(currentType.solidityType === 'uint256') {
-      const mergedUint256 = safeU256ToUint256([data[i], data[i+1]]);
+      const valuesToMerge = data[i + 1] !== undefined
+          ? [data[i], data[i + 1]]
+          : [data[i]];
+      const mergedUint256 = safeU256ToUint256(valuesToMerge);
       encodedValues.push(addHexPrefix(mergedUint256))
       i++;
       typeIndex++;
@@ -240,7 +243,10 @@ export function mergeSlots(
       const insideArray = [];
       //encodedValues.push(addHexPrefix(elementCount.toString(16)));
       for(let j = 0; j < elementCount; j++) {
-        const currentUint256 = safeU256ToUint256([data[i+1], data[i+2]]);
+        const valuesToMerge = data[i + 1] !== undefined
+          ? [data[i], data[i + 1]]
+          : [data[i]];
+        const currentUint256 = safeU256ToUint256(valuesToMerge);
         insideArray.push(addHexPrefix(currentUint256))
         i +=2
       }


### PR DESCRIPTION
Usually, a Starknet felt is represented with two values which are representing `low` and `high`. But, when the value is 0, only 1 value is returned. 

An example
```curl -X POST https:/
/free-rpc.nethermind.io/sepolia-juno \
-H "Content-Type: application/json" \
-d '{"jsonrpc":"2.0","method":"starknet_call","params":[
{"calldata:[],
"contract_address":"0x1873cf7bf6d9e446b428e8c50d7ef6f30e0fdbcce35135d47e51426c408d616",
"entry_point_selector":"0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695"},
"pending"],"id":62}'

{"jsonrpc":"2.0","result":["0x0"],"id":62}
```
