### PR TITLE
fix: improve JSON-RPC request validation

### DIFF
--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,13 +1,28 @@
 import { Response, NextFunction } from 'express'
 import { ParsedRequest, RPCError } from '../types/types'
 
+function isValidJsonRpcRequest(body: ParsedRequest): boolean {
+  // Validate types according to JSON-RPC 2.0 spec
+  return (
+    'jsonrpc' in body &&
+    'method' in body &&
+    'params' in body &&
+    'id' in body &&
+    body.jsonrpc === '2.0' &&
+    typeof body.method === 'string' &&
+    (body.params === null || typeof body.params === 'object') &&
+    (body.id === null ||
+      typeof body.id === 'string' ||
+      typeof body.id === 'number')
+  )
+}
+
 export function parseRequest(
   req: ParsedRequest,
   res: Response,
   next: NextFunction,
 ) {
-  if (req.body.jsonrpc && req.body.method && req.body.params && req.body.id) {
-    // TODO: Also validate types
+  if (isValidJsonRpcRequest(req.body)) {
     const { jsonrpc, method, params, id } = req.body
     req.rpcRequest = { jsonrpc, method, params, id }
     next()


### PR DESCRIPTION
**Description:**
According to the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification), the `id` field may be string, numbers (including 0) or `null`. Currently, the check in `parser.ts` rejects requests with `id = 0` even though they are valid. 

**Problem:**
When trying to connect to rosetta through web3py
```python
from web3 import Web3

w3 = Web3(Web3.HTTPProvider('http://localhost:3000'))
print(f"Block number: {w3.eth.block_number}")
```
the initial request made by web3py is
```
...
body: 
{
  "jsonrpc": "2.0",
  "method": "eth_blockNumber",
  "params": [],
  "id": 0
}
...
```
However, because `parser.ts` checks if `id` is truthy, the request is rejected.
```
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    w3.eth.block_number
...
 line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 405 Client Error: Method Not Allowed for url: http://localhost:3000/
```
The line causing the error
https://github.com/Digine-Labs/rosettanet/blob/e098ce99168fbbc746d64064b6a3cdc7839df227/src/utils/parser.ts#L9

**Proposed Solution:**

- Update the validation check in `parser.ts` to accept `id` values of `0` (and any other valid JSON-RPC values).
- Ensure we conform to the JSON-RPC specification by allowing id values that may be zero, null.