### PR TITLE
fix: send only "latest|pending" for starknet_getBlockWithTxs

### DIFF
--- a/src/rpc/calls/getBlockByNumber.ts
+++ b/src/rpc/calls/getBlockByNumber.ts
@@ -66,9 +66,12 @@ export async function getBlockByNumberHandler(
     }
   }
 
-  const params = isHexString(blockNumber)
-    ? [{ block_number: parseInt(blockNumber, 16) }]
-    : [{ block_number: blockNumber }]
+  const params =
+    blockNumber === 'latest' || blockNumber === 'pending'
+      ? [blockNumber]
+      : isHexString(blockNumber)
+        ? [{ block_number: parseInt(blockNumber, 16) }]
+        : [{ block_number: blockNumber }]
 
   if (isFullTxObjectRequested == true) {
     const method = 'starknet_getBlockWithTxs'


### PR DESCRIPTION
According to the [specs](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/v0.7.0/api/starknet_api_openrpc.json) of `starknet_getBlockWithTxs`,  if we send `"latest"` or `"pending"`,`params` only needs to contain one of the two.


Currently, the request send `params = [{block_number = "latest"}]`